### PR TITLE
Updated vbaws instance type to t2 for AZs that may not support t3

### DIFF
--- a/vbaws-lab-backup-primary-master.template
+++ b/vbaws-lab-backup-primary-master.template
@@ -1162,7 +1162,7 @@
             "HVM64"
           ]
         },
-        "InstanceType": "t3.medium",
+        "InstanceType": "t2.medium",
         "IamInstanceProfile": {
           "Ref": "VcbInstanceProfile"
         },


### PR DESCRIPTION
Change t3 instance type to t2 to have support for as many regions as possible so it can deploy anywhere